### PR TITLE
Support preserving user provided environment variables for blue-green

### DIFF
--- a/src/main/java/io/pivotal/services/plugin/tasks/helper/CfAppEnvDelegate.java
+++ b/src/main/java/io/pivotal/services/plugin/tasks/helper/CfAppEnvDelegate.java
@@ -1,0 +1,38 @@
+package io.pivotal.services.plugin.tasks.helper;
+
+import io.pivotal.services.plugin.CfProperties;
+import org.cloudfoundry.client.v3.applications.GetApplicationEnvironmentRequest;
+import org.cloudfoundry.operations.CloudFoundryOperations;
+import org.cloudfoundry.operations.applications.ApplicationDetail;
+import org.cloudfoundry.operations.applications.ApplicationEnvironments;
+import org.cloudfoundry.operations.applications.GetApplicationEnvironmentsRequest;
+import org.cloudfoundry.operations.applications.GetApplicationRequest;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import reactor.core.publisher.Mono;
+
+import java.util.Optional;
+
+/**
+ * Responsible for getting the environment variables of an app
+ *
+ * @author Lee Dobryden, Jonny Nabors
+ */
+public class CfAppEnvDelegate {
+
+    private static final Logger LOGGER = Logging.getLogger(CfAppEnvDelegate.class);
+
+    public Mono<Optional<ApplicationEnvironments>> getAppEnv(
+        CloudFoundryOperations cfOperations, CfProperties cfProperties) {
+        Mono<ApplicationEnvironments> applicationEnvironmentsMono = cfOperations.applications()
+            .getEnvironments(GetApplicationEnvironmentsRequest.builder().name(cfProperties.name()).build())
+            .doOnSubscribe((c) -> {
+                LOGGER.lifecycle("Checking environment of app '{}'", cfProperties.name());
+            });
+
+        return applicationEnvironmentsMono
+            .map(applicationEnvironments -> Optional.ofNullable(applicationEnvironments))
+            .onErrorResume(Exception.class, e -> Mono.just(Optional.empty()));
+    }
+
+}

--- a/src/test/java/io/pivotal/services/plugin/tasks/helper/CfAppEnvDelegateTest.java
+++ b/src/test/java/io/pivotal/services/plugin/tasks/helper/CfAppEnvDelegateTest.java
@@ -1,0 +1,86 @@
+package io.pivotal.services.plugin.tasks.helper;
+
+import io.pivotal.services.plugin.CfProperties;
+import io.pivotal.services.plugin.ImmutableCfProperties;
+import org.cloudfoundry.client.v3.applications.GetApplicationEnvironmentRequest;
+import org.cloudfoundry.operations.CloudFoundryOperations;
+import org.cloudfoundry.operations.applications.ApplicationDetail;
+import org.cloudfoundry.operations.applications.ApplicationEnvironments;
+import org.cloudfoundry.operations.applications.Applications;
+import org.cloudfoundry.operations.applications.GetApplicationEnvironmentsRequest;
+import org.cloudfoundry.operations.applications.GetApplicationRequest;
+import org.junit.Test;
+import reactor.core.publisher.Mono;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class CfAppEnvDelegateTest {
+
+    private CfAppEnvDelegate appEnvDelegate = new CfAppEnvDelegate();
+
+
+    @Test
+    public void testGetEnvironmentsNoException() {
+        CloudFoundryOperations cfOperations = mock(CloudFoundryOperations.class);
+        CfProperties cfAppProperties = sampleApp();
+
+        ApplicationEnvironments appEnvironment = sampleAppEnvironment();
+
+        Applications mockApplications = mock(Applications.class);
+        when(cfOperations.applications()).thenReturn(mockApplications);
+
+        when(mockApplications.getEnvironments(any(GetApplicationEnvironmentsRequest.class))).thenReturn(Mono.just(appEnvironment));
+
+        Mono<Optional<ApplicationEnvironments>> appEnvMono = appEnvDelegate.getAppEnv(cfOperations, cfAppProperties);
+
+        assertThat(appEnvMono.block().isPresent()).isTrue();
+    }
+
+    @Test
+    public void testGetEnvironmentsNoApplication() {
+        CloudFoundryOperations cfOperations = mock(CloudFoundryOperations.class);
+        CfProperties cfAppProperties = sampleApp();
+
+        Applications mockApplications = mock(Applications.class);
+        when(cfOperations.applications()).thenReturn(mockApplications);
+
+        when(mockApplications.getEnvironments(any(GetApplicationEnvironmentsRequest.class)))
+            .thenReturn(Mono.error(new RuntimeException("No such Environment")));
+
+        Mono<Optional<ApplicationEnvironments>> appDetailsMono = appEnvDelegate.getAppEnv(cfOperations, cfAppProperties);
+
+        Optional<ApplicationEnvironments> appDetailOptional = appDetailsMono.block();
+
+        assertThat(appDetailOptional.isPresent()).isFalse();
+    }
+
+
+    private ApplicationEnvironments sampleAppEnvironment() {
+        Map<String, String> userVars = new HashMap<>();
+        userVars.put("prop", "value");
+
+        return ApplicationEnvironments.builder()
+            .userProvided(userVars)
+            .build();
+    }
+
+    private CfProperties sampleApp() {
+        return ImmutableCfProperties.builder()
+            .ccHost("cchost")
+            .ccUser("ccuser")
+            .ccPassword("ccpassword")
+            .org("org")
+            .space("space")
+            .name("test")
+            .host("test")
+            .build();
+    }
+
+}


### PR DESCRIPTION
This commit adds the ability to read existing user-provided environment variables from the app running in PCF when doing blue-green deploys. It will merge variables provided in cfConfig with any existing ones in PCF. The cfConfig section takes precedence when environment variables have duplicate keys. 

We found this helpful when only wanting to store private keys in PCF, and not within the repo. 

Signed-off-by: Jonny Nabors <jonnynabors@gmail.com>