### PR TITLE
Supports overriding creds via environment variables

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -94,6 +94,15 @@ cfConfig {
 ./gradlew cf-push -Pcf.name=Green -Pcf.host=demo-time-temp -Pcf.environment.SPRING_PROFILES_ACTIVE="cloud,dev"
 ----
 
+* User and Password can be overridden using environment variables:
+
+[source]
+----
+export CF_CCUSER=admin
+export CF_CCPASSWORD=admin
+./gradlew cf-push
+----
+
 * There is one task to retrieve the details of an application (cf-get-app-detail).
 You can use this task in the following way, say to retrieve the app url's in a gradle task:
 

--- a/src/main/java/io/pivotal/services/plugin/CfPropertiesMapper.java
+++ b/src/main/java/io/pivotal/services/plugin/CfPropertiesMapper.java
@@ -18,7 +18,11 @@ package io.pivotal.services.plugin;
 
 import org.gradle.api.Project;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 /**
  * Responsible for mapping plugin extension provided via a block
@@ -46,8 +50,17 @@ public class CfPropertiesMapper {
 
     private final Project project;
 
+    private final Map<String, String> systemEnv;
+
     public CfPropertiesMapper(Project project) {
         this.project = project;
+        this.systemEnv = System.getenv();
+    }
+
+    //For Tests
+    CfPropertiesMapper(Project project, Map<String, String> systemEnv) {
+        this.project = project;
+        this.systemEnv = systemEnv;
     }
 
     public CfProperties getProperties() {
@@ -189,13 +202,17 @@ public class CfPropertiesMapper {
     }
 
     public String getCcUser() {
-        return getStringPropertyFromProject(PropertyNameConstants.CC_USER)
-            .orElse(this.getExtension().getCcUser());
+        return getPropertyFromEnvironment(PropertyNameConstants.CC_USER_ENV)
+            .orElse(
+                this.getStringPropertyFromProject(PropertyNameConstants.CC_USER)
+                    .orElse(this.getExtension().getCcUser()));
+
     }
 
     public String getCcPassword() {
-        return getStringPropertyFromProject(PropertyNameConstants.CC_PASSWORD)
-            .orElse(this.getExtension().getCcPassword());
+        return getPropertyFromEnvironment(PropertyNameConstants.CC_PASSWORD_ENV)
+            .orElse(getStringPropertyFromProject(PropertyNameConstants.CC_PASSWORD)
+                .orElse(this.getExtension().getCcPassword()));
     }
 
     public String getCcToken() {
@@ -272,6 +289,13 @@ public class CfPropertiesMapper {
         }
 
         return withProperties;
+    }
+
+    public Optional<String> getPropertyFromEnvironment(String propertyName) {
+        if (this.systemEnv.containsKey(propertyName)) {
+            return Optional.of((String) this.systemEnv.get(propertyName));
+        }
+        return Optional.empty();
     }
 
     public Optional<String> getStringPropertyFromProject(String propertyName) {

--- a/src/main/java/io/pivotal/services/plugin/PropertyNameConstants.java
+++ b/src/main/java/io/pivotal/services/plugin/PropertyNameConstants.java
@@ -12,7 +12,9 @@ public interface PropertyNameConstants {
     String CF_FILE_PATH = "cf.filePath";
     String CC_HOST = "cf.ccHost";
     String CC_USER = "cf.ccUser";
+    String CC_USER_ENV = "CF_CCUSER";
     String CC_PASSWORD = "cf.ccPassword";
+    String CC_PASSWORD_ENV = "CF_CCPASSWORD";
     String CF_ORG = "cf.org";
     String CF_SPACE = "cf.space";
     String CF_BUILDPACK = "cf.buildpack";

--- a/src/test/java/io/pivotal/services/plugin/CfPropertiesEnvOverrideTest.java
+++ b/src/test/java/io/pivotal/services/plugin/CfPropertiesEnvOverrideTest.java
@@ -1,0 +1,74 @@
+package io.pivotal.services.plugin;
+
+import org.gradle.api.Project;
+import org.gradle.api.plugins.ExtensionContainer;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class CfPropertiesEnvOverrideTest {
+
+    private Project project;
+
+    private CfPluginExtension pluginExtension;
+
+    private Map<String, Object> currentProjectProperties = new HashMap<>();
+
+    @Before
+    public void setUp() {
+        this.project = mock(Project.class);
+        ExtensionContainer extensionContainer = mock(ExtensionContainer.class);
+        this.pluginExtension = sampleExtension(this.project);
+        when(extensionContainer.findByType(CfPluginExtension.class)).thenReturn(this.pluginExtension);
+        when(this.project.getExtensions()).thenReturn(extensionContainer);
+    }
+
+
+    @Test
+    public void testCcUserIsOverriddenViaEnvProperty() {
+        Map<String, String> env = getEnvWithProperties("CF_CCUSER", "envuser");
+        CfPropertiesMapper cfPropertiesMapper = new CfPropertiesMapper(this.project, env);
+
+        CfProperties props = cfPropertiesMapper.getProperties();
+
+        assertThat(props.ccUser()).isEqualTo("envuser");
+    }
+
+
+    @Test
+    public void testCcPasswordIsOverriddenViaEnv() {
+        Map<String, String> env = getEnvWithProperties("CF_CCPASSWORD", "envpasswd");
+        CfPropertiesMapper cfPropertiesMapper = new CfPropertiesMapper(this.project, env);
+        CfProperties props = cfPropertiesMapper.getProperties();
+
+        assertThat(props.ccPassword()).isEqualTo("envpasswd");
+    }
+
+
+    private Map<String, String> getEnvWithProperties(String propertyName, String propertyValue) {
+        Map<String, String> env = new HashMap<>();
+        env.put(propertyName, propertyValue);
+        return env;
+    }
+
+
+    private CfPluginExtension sampleExtension(Project project) {
+        CfPluginExtension ext = new CfPluginExtension(project);
+        ext.setName("name-fromplugin");
+        ext.setCcUser("ccuser-fromplugin");
+        ext.setCcHost("cchost-fromplugin");
+        ext.setCcPassword("ccpassword-fromplugin");
+        ext.setOrg("org-fromplugin");
+        ext.setSpace("space-fromplugin");
+        ext.setHost("route-fromplugin");
+        ext.setHost("hostname-fromplugin");
+
+        return ext;
+    }
+}

--- a/src/test/java/io/pivotal/services/plugin/CfPropertiesMapperTest.java
+++ b/src/test/java/io/pivotal/services/plugin/CfPropertiesMapperTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2013-2016 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package io.pivotal.services.plugin;
 
 import org.gradle.api.Project;
@@ -21,7 +5,12 @@ import org.gradle.api.plugins.ExtensionContainer;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;


### PR DESCRIPTION
Fixes #21 - Provides a way to override creds via environment variables, this way not having to specify it via cfConfig block or via gradle properties