### PR TITLE
Remove dependency on Gradle Strings library

### DIFF
--- a/src/main/java/io/pivotal/services/plugin/CfPropertiesMapper.java
+++ b/src/main/java/io/pivotal/services/plugin/CfPropertiesMapper.java
@@ -17,9 +17,9 @@
 package io.pivotal.services.plugin;
 
 import org.gradle.api.Project;
-import org.gradle.internal.impldep.aQute.lib.strings.Strings;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -313,7 +313,8 @@ public class CfPropertiesMapper {
 
     public Optional<List<String>> getListPropertyFromProject(String propertyName) {
         if (this.project.hasProperty(propertyName)) {
-            return Optional.of(Strings.split((String) this.project.property(propertyName)));
+            String rawProperty = (String) this.project.property(propertyName);
+            return Optional.of((Arrays.asList(rawProperty.split(","))));
         }
         return Optional.empty();
     }


### PR DESCRIPTION
Hey Biju,

We're seeing an error from the published plugin related to the changes we made for overriding services via the command line. When we used it, it couldn't find the `org.gradle.internal.impldep.aQute.lib.strings.Strings;` library, so we reimplemented  this with a basic String split. 

Signed-off-by: Jonathan Nabors <jnabors@ford.com>