### PR TITLE
domain cache to support multiple PCF servers in the same run

### DIFF
--- a/src/main/java/io/pivotal/services/plugin/tasks/AbstractCfTask.java
+++ b/src/main/java/io/pivotal/services/plugin/tasks/AbstractCfTask.java
@@ -4,6 +4,7 @@ import io.pivotal.services.plugin.CfPluginExtension;
 import io.pivotal.services.plugin.CfProperties;
 import io.pivotal.services.plugin.CfPropertiesMapper;
 import io.pivotal.services.plugin.CfProxySettingsDetail;
+import io.pivotal.services.plugin.CfRouteUtil;
 import io.pivotal.services.plugin.cf.StaticTokenProvider;
 import org.cloudfoundry.client.CloudFoundryClient;
 import org.cloudfoundry.operations.CloudFoundryOperations;
@@ -51,12 +52,13 @@ abstract class AbstractCfTask extends DefaultTask {
             .tokenProvider(tokenProvider)
             .build();
 
-        CloudFoundryOperations cfOperations = DefaultCloudFoundryOperations.builder()
+        DefaultCloudFoundryOperations cfOperations = DefaultCloudFoundryOperations.builder()
             .cloudFoundryClient(cfClient)
             .organization(cfAppProperties.org())
             .space(cfAppProperties.space())
             .build();
 
+        populateDomainCache(cfOperations);
         return cfOperations;
     }
 
@@ -98,6 +100,10 @@ abstract class AbstractCfTask extends DefaultTask {
 
     protected CfProperties getCfProperties() {
         return this.cfPropertiesMapper.getProperties();
+    }
+
+    private void populateDomainCache(DefaultCloudFoundryOperations cfOperations) {
+        CfRouteUtil.cacheDomainSummaries(cfOperations);
     }
 
     @Override

--- a/src/main/java/io/pivotal/services/plugin/tasks/AbstractCfTask.java
+++ b/src/main/java/io/pivotal/services/plugin/tasks/AbstractCfTask.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 
 /**
  * Base class for all Concrete CF tasks
+ * @author Gabriel Couto (@gmcouto)
  */
 abstract class AbstractCfTask extends DefaultTask {
 

--- a/src/main/java/io/pivotal/services/plugin/tasks/helper/CfBlueGreenStage1Delegate.java
+++ b/src/main/java/io/pivotal/services/plugin/tasks/helper/CfBlueGreenStage1Delegate.java
@@ -32,8 +32,6 @@ public class CfBlueGreenStage1Delegate {
 
     public Mono<Void> runStage1(Project project, CloudFoundryOperations cfOperations,
                                 CfProperties cfProperties) {
-        //eagerly cache domain summaries
-        CfRouteUtil.getDomainSummaries(cfOperations);
         
         final String greenNameString = cfProperties.name() + "-green";
         final String greenRouteString = CfRouteUtil.getTempRoute(cfOperations, cfProperties, "-green");

--- a/src/main/java/io/pivotal/services/plugin/tasks/helper/CfBlueGreenStage2Delegate.java
+++ b/src/main/java/io/pivotal/services/plugin/tasks/helper/CfBlueGreenStage2Delegate.java
@@ -61,9 +61,6 @@ public class CfBlueGreenStage2Delegate {
     public Mono<Void> runStage2(Project project, CloudFoundryOperations cfOperations,
                                 CfProperties cfProperties) {
         
-        //eagerly cache domain summaries
-        CfRouteUtil.getDomainSummaries(cfOperations);
-        
         String greenNameString = cfProperties.name() + "-green";
         String greenRouteString = CfRouteUtil.getTempRoute(cfOperations, cfProperties, "-green");
 


### PR DESCRIPTION
This Pull Request is a result of discussions of my last Pull Request. https://github.com/pivotalservices/ya-cf-app-gradle-plugin/pull/27

Things that I did in this PR:
- I have modified the app to allow a cache based on the server used to connect to PCF, so different PCF servers can be used in the same run
- I have also moved eager cache to AbstractCfTask to prevent that a CfOperations go uncached.
- Also have split the code that does the caching, fetching and populate the cache, so no one misuses it