### PR TITLE
Manifest routes not being read, and override capabilities.

### DIFF
--- a/src/main/java/io/pivotal/services/plugin/CfManifestUtil.java
+++ b/src/main/java/io/pivotal/services/plugin/CfManifestUtil.java
@@ -29,7 +29,7 @@ public class CfManifestUtil {
         if(properties.filePath() != null)
             builder.path(new File(properties.filePath()).toPath());
         if(properties.services() != null && !properties.services().isEmpty())
-            builder.addAllServices(properties.services());
+            builder.services(properties.services());
         if(properties.host() != null)
             builder.host(properties.host());
         if(properties.domain() != null)

--- a/src/main/java/io/pivotal/services/plugin/CfPropertiesMapper.java
+++ b/src/main/java/io/pivotal/services/plugin/CfPropertiesMapper.java
@@ -24,6 +24,7 @@ import org.gradle.api.Project;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -267,8 +268,9 @@ public class CfPropertiesMapper {
 
     public List<String> getServices() {
         return firstNonEmptyOptional(() -> getListPropertyFromProject(PropertyNameConstants.CF_SERVICES),
-            () -> Optional.ofNullable(this.getExtension().getServices()),
-            () -> fromManifest(m -> m.getServices())
+            () -> Optional.ofNullable(this.getExtension().getServices().isEmpty() ? null : this.getExtension().getServices()),
+            () -> fromManifest(m -> m.getServices()),
+            () -> Optional.ofNullable(Collections.emptyList())
         );
     }
 
@@ -303,8 +305,9 @@ public class CfPropertiesMapper {
 
     public List<String> getAppRoutes() {
         return firstNonEmptyOptional(() -> getListPropertyFromProject(PropertyNameConstants.CF_APPLICATION_ROUTES),
-            () -> Optional.ofNullable(this.getExtension().getRoutes()),
-            () -> fromManifest(m -> m.getRoutes().stream().map(Route::getRoute).collect(Collectors.toList()))
+            () -> Optional.ofNullable(this.getExtension().getRoutes().isEmpty() ? null : this.getExtension().getRoutes()),
+            () -> fromManifest(m -> m.getRoutes().stream().map(Route::getRoute).collect(Collectors.toList())),
+            () -> Optional.ofNullable(Collections.emptyList())
         );
     }
 

--- a/src/main/java/io/pivotal/services/plugin/CfPropertiesMapper.java
+++ b/src/main/java/io/pivotal/services/plugin/CfPropertiesMapper.java
@@ -71,13 +71,10 @@ public class CfPropertiesMapper {
     CfPropertiesMapper(Project project, Map<String, String> systemEnv) {
         this.project = project;
         this.systemEnv = systemEnv;
-        String manifestPath = getManifestPath();
-        if (manifestPath != null) {
-            manifest = ApplicationManifestUtils.read(new File(getManifestPath()).toPath()).get(0);
-        }
     }
 
     public CfProperties getProperties() {
+        refreshManifest();
         return ImmutableCfProperties.builder()
             .name(getCfApplicationName())
             .ccHost(getCcHost())
@@ -113,6 +110,11 @@ public class CfPropertiesMapper {
             .cfUserProvidedServices(this.getCfUserProvidedServices())
             .cfProxySettings(this.getCfProxySettings())
             .build();
+    }
+
+    private void refreshManifest() {
+        String manifestPath = getManifestPath();
+        manifest =  manifestPath != null ? ApplicationManifestUtils.read(new File(manifestPath).toPath()).get(0) : null;
     }
 
     private List<CfServiceDetail> getCfServices() {

--- a/src/test/java/io/pivotal/services/plugin/CfManifestUtilTest.java
+++ b/src/test/java/io/pivotal/services/plugin/CfManifestUtilTest.java
@@ -1,0 +1,34 @@
+package io.pivotal.services.plugin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+
+import org.cloudfoundry.operations.applications.ApplicationManifest;
+import org.junit.Test;
+
+public class CfManifestUtilTest {
+    @Test
+    public void testIfServicesAreCorrect() {
+        final String A_SERVICE = "a-service-1";
+        CfProperties cfProperties = mock(CfProperties.class);
+        when(cfProperties.name()).thenReturn("because-name-cant-be-null");
+        when(cfProperties.services()).thenReturn(Collections.singletonList(A_SERVICE));
+        ApplicationManifest manifest = CfManifestUtil.convert(cfProperties);
+        assertThat(manifest.getServices().size()).isEqualTo(1);
+        assertThat(manifest.getServices().get(0)).isEqualTo(A_SERVICE);
+    }
+
+    @Test
+    public void testIfRoutesAreCorrect() {
+        final String A_ROUTE = "a-route-1.domain.com";
+        CfProperties cfProperties = mock(CfProperties.class);
+        when(cfProperties.name()).thenReturn("because-name-cant-be-null");
+        when(cfProperties.routes()).thenReturn(Collections.singletonList(A_ROUTE));
+        ApplicationManifest manifest = CfManifestUtil.convert(cfProperties);
+        assertThat(manifest.getRoutes().size()).isEqualTo(1);
+        assertThat(manifest.getRoutes().get(0).getRoute()).isEqualTo(A_ROUTE);
+    }
+}


### PR DESCRIPTION
Following the latest PRs #27 and #28, I have fixed a bug where 

- manifest routes were not being read because extension routes is always an empty list.
- I have also added the capability to override the manifest path, with a valid one or not, during build execution.
- Additionally, I noticed that now that `CfManifestUtil` had a bug that it would load the service list twice now that `CfProperitesMapper` loads defaults from manifest correctly.