### PR TITLE
green blue push shouldn't reuse blue instance environment configuration.

### DIFF
--- a/src/main/java/io/pivotal/services/plugin/tasks/helper/CfBlueGreenStage1Delegate.java
+++ b/src/main/java/io/pivotal/services/plugin/tasks/helper/CfBlueGreenStage1Delegate.java
@@ -59,8 +59,7 @@ public class CfBlueGreenStage1Delegate {
                     .withRoutes(Collections.singletonList(greenRouteString))
                     .withInstances(appDetail.getInstances())
                     .withMemory(appDetail.getMemoryLimit())
-                    .withDiskQuota(appDetail.getDiskQuota())
-                    .withEnvironment(userEnvs);
+                    .withDiskQuota(appDetail.getDiskQuota());
             }).orElse(ImmutableCfProperties.copyOf(cfProperties)
                 .withName(greenNameString)
                 .withHost(null)

--- a/src/test/java/io/pivotal/services/plugin/tasks/helper/CfBlueGreenStage1DelegateTest.java
+++ b/src/test/java/io/pivotal/services/plugin/tasks/helper/CfBlueGreenStage1DelegateTest.java
@@ -92,7 +92,6 @@ public class CfBlueGreenStage1DelegateTest {
         verify(this.pushDelegate).push(any(CloudFoundryOperations.class), argumentCaptor.capture());
 
         Map<String, String> expectedEnvironment = getUserEnvironment();
-        expectedEnvironment.putAll(existingEnvironment);
 
         CfProperties captured = argumentCaptor.getValue();
         assertThat(captured.name()).isEqualTo("test-green");


### PR DESCRIPTION
When pushing a new green application, the current implementation is reusing the blue application instance numbers, memory limit, disk quota and environment.

There is no need for all that, as whenever a user is pushing a new application, the user is supposed to provide a source of truth, which is usually a config file or a manifest.

It is quite weird to push a new green application, **and it fails to start** because it is trying to reuse outdated configuration from the blue application. You might waste a lot of time trying to figure out why those environments keep poping up.

In this changeset, **I have removed _only_ the reuse of environment.**

If approved, I have already code changes for disk quota, memory and instance numbers... ready for another PR. Although those are not urgent.