### PR TITLE
Removes cache for domains

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,8 +12,8 @@ buildscript {
         classpath "com.netflix.nebula:nebula-release-plugin:6.0.2"
     }
     ext {
-        cfClientVersion = "3.9.0.RELEASE"
-        cfReactorTestVersion = "3.1.5.RELEASE"
+        cfClientVersion = "3.13.0.RELEASE"
+        cfReactorTestVersion = "3.1.8.RELEASE"
     }
 }
 

--- a/src/main/java/io/pivotal/services/plugin/tasks/AbstractCfTask.java
+++ b/src/main/java/io/pivotal/services/plugin/tasks/AbstractCfTask.java
@@ -59,7 +59,6 @@ abstract class AbstractCfTask extends DefaultTask {
             .space(cfAppProperties.space())
             .build();
 
-        populateDomainCache(cfOperations);
         return cfOperations;
     }
 
@@ -101,10 +100,6 @@ abstract class AbstractCfTask extends DefaultTask {
 
     protected CfProperties getCfProperties() {
         return this.cfPropertiesMapper.getProperties();
-    }
-
-    private void populateDomainCache(DefaultCloudFoundryOperations cfOperations) {
-        CfRouteUtil.cacheDomainSummaries(cfOperations);
     }
 
     @Override

--- a/src/main/java/io/pivotal/services/plugin/tasks/CfMapRouteTask.java
+++ b/src/main/java/io/pivotal/services/plugin/tasks/CfMapRouteTask.java
@@ -4,6 +4,7 @@ import io.pivotal.services.plugin.CfProperties;
 import io.pivotal.services.plugin.tasks.helper.CfMapRouteDelegate;
 import org.cloudfoundry.operations.CloudFoundryOperations;
 import org.gradle.api.tasks.TaskAction;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.time.Duration;
@@ -23,9 +24,9 @@ public class CfMapRouteTask extends AbstractCfTask {
         CloudFoundryOperations cfOperations = getCfOperations();
         CfProperties cfProperties = getCfProperties();
 
-        Mono<Void> resp = mapRouteDelegate.mapRoute(cfOperations, cfProperties);
+        Flux<Integer> resp = mapRouteDelegate.mapRoute(cfOperations, cfProperties);
 
-        resp.block(Duration.ofMillis(defaultWaitTimeout));
+        resp.collectList().block(Duration.ofMillis(defaultWaitTimeout));
 
     }
 

--- a/src/main/java/io/pivotal/services/plugin/tasks/CfUnMapRouteTask.java
+++ b/src/main/java/io/pivotal/services/plugin/tasks/CfUnMapRouteTask.java
@@ -4,6 +4,7 @@ import io.pivotal.services.plugin.CfProperties;
 import io.pivotal.services.plugin.tasks.helper.CfUnMapRouteDelegate;
 import org.cloudfoundry.operations.CloudFoundryOperations;
 import org.gradle.api.tasks.TaskAction;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.time.Duration;
@@ -23,10 +24,9 @@ public class CfUnMapRouteTask extends AbstractCfTask {
         CloudFoundryOperations cfOperations = getCfOperations();
         CfProperties cfProperties = getCfProperties();
 
-        Mono<Void> resp = this.unMapRouteTaskDelegate.unmapRoute(cfOperations, cfProperties);
+        Flux<Void> resp = this.unMapRouteTaskDelegate.unmapRoute(cfOperations, cfProperties);
 
-        resp.block(Duration.ofMillis(defaultWaitTimeout));
-
+        resp.collectList().block(Duration.ofMillis(defaultWaitTimeout));
     }
 
     @Override

--- a/src/main/java/io/pivotal/services/plugin/tasks/helper/CfBlueGreenStage1Delegate.java
+++ b/src/main/java/io/pivotal/services/plugin/tasks/helper/CfBlueGreenStage1Delegate.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 import static org.cloudfoundry.util.tuple.TupleUtils.function;
 
 /**
+ * @author Biju Kunjummen
  * @author Gabriel Couto
  */
 public class CfBlueGreenStage1Delegate {
@@ -32,7 +33,7 @@ public class CfBlueGreenStage1Delegate {
                                 CfProperties cfProperties) {
         
         final String greenNameString = cfProperties.name() + "-green";
-        final String greenRouteString = CfRouteUtil.getTempRoute(cfOperations, cfProperties, "-green");
+        final Mono<String> greenRouteStringMono = CfRouteUtil.getTempRoute(cfOperations, cfProperties, "-green");
 
         Mono<Optional<ApplicationDetail>> appDetailMono = appDetailsDelegate
             .getAppDetails(cfOperations, cfProperties);
@@ -41,7 +42,7 @@ public class CfBlueGreenStage1Delegate {
         Mono<Optional<ApplicationEnvironments>> appEnvMono =
             appEnvDelegate.getAppEnv(cfOperations, cfProperties);
 
-        Mono<ImmutableCfProperties> cfPropertiesMono = Mono.zip(appEnvMono, appDetailMono).map(function((appEnvOpt, appDetailOpt) -> {
+        Mono<ImmutableCfProperties> cfPropertiesMono = Mono.zip(appEnvMono, appDetailMono, greenRouteStringMono).map(function((appEnvOpt, appDetailOpt, greenRouteString) -> {
             LOGGER.lifecycle(
                 "Running Blue Green Deploy - deploying a 'green' app. App '{}' with route '{}'",
                 cfProperties.name(),

--- a/src/main/java/io/pivotal/services/plugin/tasks/helper/CfMapRouteDelegate.java
+++ b/src/main/java/io/pivotal/services/plugin/tasks/helper/CfMapRouteDelegate.java
@@ -23,14 +23,14 @@ public class CfMapRouteDelegate {
     private static final Logger LOGGER = Logging.getLogger(CfMapRouteDelegate.class);
 
     public Flux<Integer> mapRoute(CloudFoundryOperations cfOperations,
-                               CfProperties cfProperties) {
+                                  CfProperties cfProperties) {
         if (cfProperties.routes() != null && !cfProperties.routes().isEmpty()) {
-            Mono<List<DecomposedRoute>> routesMono = CfRouteUtil.decomposedRoutes(cfOperations,cfProperties.routes(),cfProperties.path());
-            Flux<DecomposedRoute> routesFlux = routesMono.flatMapIterable(decomposedRoutes -> decomposedRoutes);
+            Mono<List<DecomposedRoute>> decomposedRoutes = CfRouteUtil.decomposedRoutes(cfOperations, cfProperties.routes(), cfProperties.path());
 
-            return routesFlux
+            return decomposedRoutes
+                .flatMapMany(Flux::fromIterable)
                 .flatMap(route ->
-                        mapRoute(cfOperations, cfProperties.name(), route.getHost(), route.getDomain(), route.getPort(), route.getPath()));
+                    mapRoute(cfOperations, cfProperties.name(), route.getHost(), route.getDomain(), route.getPort(), route.getPath()));
 
         } else {
             return mapRoute(cfOperations, cfProperties.name(), cfProperties.host(), cfProperties.domain(), null, cfProperties.path()).flux();

--- a/src/main/java/io/pivotal/services/plugin/tasks/helper/CfMapRouteDelegate.java
+++ b/src/main/java/io/pivotal/services/plugin/tasks/helper/CfMapRouteDelegate.java
@@ -1,7 +1,5 @@
 package io.pivotal.services.plugin.tasks.helper;
 
-import java.util.List;
-
 import io.pivotal.services.plugin.CfProperties;
 import io.pivotal.services.plugin.CfRouteUtil;
 import org.cloudfoundry.operations.CloudFoundryOperations;
@@ -9,7 +7,10 @@ import org.cloudfoundry.operations.applications.DecomposedRoute;
 import org.cloudfoundry.operations.routes.MapRouteRequest;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+
+import java.util.List;
 
 /**
  * Helper class for mapping a route
@@ -21,22 +22,22 @@ public class CfMapRouteDelegate {
 
     private static final Logger LOGGER = Logging.getLogger(CfMapRouteDelegate.class);
 
-    public Mono<Void> mapRoute(CloudFoundryOperations cfOperations,
+    public Flux<Integer> mapRoute(CloudFoundryOperations cfOperations,
                                CfProperties cfProperties) {
-        Mono<Void> resp = Mono.empty();
         if (cfProperties.routes() != null && !cfProperties.routes().isEmpty()) {
-            List<DecomposedRoute> routes = CfRouteUtil.decomposedRoutes(cfOperations,cfProperties.routes(),cfProperties.path());
-            for(DecomposedRoute route: routes) {
-                resp = resp.then(mapRoute(cfOperations, cfProperties.name(), route.getHost(), route.getDomain(), route.getPort(), route.getPath()));
-            }
-        } else {
-            resp = resp.then(mapRoute(cfOperations, cfProperties.name(), cfProperties.host(), cfProperties.domain(), null, cfProperties.path()));
-        }
+            Mono<List<DecomposedRoute>> routesMono = CfRouteUtil.decomposedRoutes(cfOperations,cfProperties.routes(),cfProperties.path());
+            Flux<DecomposedRoute> routesFlux = routesMono.flatMapIterable(decomposedRoutes -> decomposedRoutes);
 
-        return resp;
+            return routesFlux
+                .flatMap(route ->
+                        mapRoute(cfOperations, cfProperties.name(), route.getHost(), route.getDomain(), route.getPort(), route.getPath()));
+
+        } else {
+            return mapRoute(cfOperations, cfProperties.name(), cfProperties.host(), cfProperties.domain(), null, cfProperties.path()).flux();
+        }
     }
 
-    private Mono<Void> mapRoute(CloudFoundryOperations cfOperations, String appName, String host, String domain, Integer port, String path) {
+    private Mono<Integer> mapRoute(CloudFoundryOperations cfOperations, String appName, String host, String domain, Integer port, String path) {
         return cfOperations.routes()
             .map(MapRouteRequest
                 .builder()
@@ -45,7 +46,7 @@ public class CfMapRouteDelegate {
                 .domain(domain)
                 .port(port)
                 .path(path)
-                .build()).then().doOnSubscribe((s) -> {
+                .build()).doOnSubscribe((s) -> {
                 LOGGER.lifecycle("Mapping hostname '{}' in domain '{}' with path '{}' of app '{}'", host,
                     domain, path, appName);
             });

--- a/src/main/java/io/pivotal/services/plugin/tasks/helper/CfUnMapRouteDelegate.java
+++ b/src/main/java/io/pivotal/services/plugin/tasks/helper/CfUnMapRouteDelegate.java
@@ -25,10 +25,10 @@ public class CfUnMapRouteDelegate {
     public Flux<Void> unmapRoute(CloudFoundryOperations cfOperations, CfProperties cfProperties) {
 
         if (cfProperties.routes() != null && !cfProperties.routes().isEmpty()) {
-            Mono<List<DecomposedRoute>> routesMono = CfRouteUtil.decomposedRoutes(cfOperations,cfProperties.routes(),cfProperties.path());
-            Flux<DecomposedRoute> routesFlux = routesMono.flatMapIterable(decomposedRoutes -> decomposedRoutes);
+            Mono<List<DecomposedRoute>> decomposedRoutes = CfRouteUtil.decomposedRoutes(cfOperations, cfProperties.routes(), cfProperties.path());
 
-            Flux<Void> unmapRoutesFlux = routesFlux
+            Flux<Void> unmapRoutesFlux = decomposedRoutes
+                .flatMapMany(Flux::fromIterable)
                 .flatMap(route ->
                     unmapRoute(cfOperations, cfProperties.name(), route.getHost(), route.getDomain(), route.getPort(), route.getPath()));
 

--- a/src/main/java/io/pivotal/services/plugin/tasks/helper/CfUnMapRouteDelegate.java
+++ b/src/main/java/io/pivotal/services/plugin/tasks/helper/CfUnMapRouteDelegate.java
@@ -7,6 +7,7 @@ import org.cloudfoundry.operations.applications.DecomposedRoute;
 import org.cloudfoundry.operations.routes.UnmapRouteRequest;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
@@ -21,18 +22,21 @@ public class CfUnMapRouteDelegate {
 
     private static final Logger LOGGER = Logging.getLogger(CfUnMapRouteDelegate.class);
 
-    public Mono<Void> unmapRoute(CloudFoundryOperations cfOperations, CfProperties cfProperties) {
-        Mono<Void> resp = Mono.empty();
+    public Flux<Void> unmapRoute(CloudFoundryOperations cfOperations, CfProperties cfProperties) {
 
         if (cfProperties.routes() != null && !cfProperties.routes().isEmpty()) {
-            List<DecomposedRoute> routes = CfRouteUtil.decomposedRoutes(cfOperations, cfProperties.routes(), cfProperties.path());
-            for (DecomposedRoute route : routes) {
-                resp = resp.then(unmapRoute(cfOperations, cfProperties.name(), route.getHost(), route.getDomain(), route.getPort(), route.getPath()));
-            }
+            Mono<List<DecomposedRoute>> routesMono = CfRouteUtil.decomposedRoutes(cfOperations,cfProperties.routes(),cfProperties.path());
+            Flux<DecomposedRoute> routesFlux = routesMono.flatMapIterable(decomposedRoutes -> decomposedRoutes);
+
+            Flux<Void> unmapRoutesFlux = routesFlux
+                .flatMap(route ->
+                    unmapRoute(cfOperations, cfProperties.name(), route.getHost(), route.getDomain(), route.getPort(), route.getPath()));
+
+            return unmapRoutesFlux;
+            
         } else {
-            resp = resp.then(unmapRoute(cfOperations, cfProperties.name(), cfProperties.host(), cfProperties.domain(), null, cfProperties.path()));
+            return unmapRoute(cfOperations, cfProperties.name(), cfProperties.host(), cfProperties.domain(), null, cfProperties.path()).flux();
         }
-        return resp;
     }
 
     private Mono<Void> unmapRoute(CloudFoundryOperations cfOperations, String appName, String host, String domain, Integer port, String path) {

--- a/src/test/java/io/pivotal/services/plugin/tasks/helper/CfBlueGreenStage2DelegateTest.java
+++ b/src/test/java/io/pivotal/services/plugin/tasks/helper/CfBlueGreenStage2DelegateTest.java
@@ -67,8 +67,8 @@ public class CfBlueGreenStage2DelegateTest {
         when(detailsTaskDelegate.getAppDetails(any(CloudFoundryOperations.class), any(CfProperties.class)))
             .thenReturn(Mono.just(Optional.empty()));
 
-        when(this.mapRouteDelegate.mapRoute(any(CloudFoundryOperations.class), any(CfProperties.class))).thenReturn(Mono.empty());
-        when(this.unMapRouteDelegate.unmapRoute(any(CloudFoundryOperations.class), any(CfProperties.class))).thenReturn(Mono.empty());
+        when(this.mapRouteDelegate.mapRoute(any(CloudFoundryOperations.class), any(CfProperties.class))).thenReturn(Flux.empty());
+        when(this.unMapRouteDelegate.unmapRoute(any(CloudFoundryOperations.class), any(CfProperties.class))).thenReturn(Flux.empty());
         when(this.renameAppTaskDelegate.renameApp(any(CloudFoundryOperations.class), any(CfProperties.class), any(CfProperties.class))).thenReturn(Mono.empty());
         when(this.deleteAppTaskDelegate.deleteApp(any(CloudFoundryOperations.class), any(CfProperties.class))).thenReturn(Mono.empty());
         when(this.stopDelegate.stopApp(any(CloudFoundryOperations.class), any(CfProperties.class))).thenReturn(Mono.empty());
@@ -104,8 +104,8 @@ public class CfBlueGreenStage2DelegateTest {
         when(detailsTaskDelegate.getAppDetails(any(CloudFoundryOperations.class), any(CfProperties.class)))
             .thenReturn(Mono.just(Optional.of(sampleApplicationDetail())));
 
-        when(this.mapRouteDelegate.mapRoute(any(CloudFoundryOperations.class), any(CfProperties.class))).thenReturn(Mono.empty());
-        when(this.unMapRouteDelegate.unmapRoute(any(CloudFoundryOperations.class), any(CfProperties.class))).thenReturn(Mono.empty());
+        when(this.mapRouteDelegate.mapRoute(any(CloudFoundryOperations.class), any(CfProperties.class))).thenReturn(Flux.empty());
+        when(this.unMapRouteDelegate.unmapRoute(any(CloudFoundryOperations.class), any(CfProperties.class))).thenReturn(Flux.empty());
         when(this.renameAppTaskDelegate.renameApp(any(CloudFoundryOperations.class), any(CfProperties.class), any(CfProperties.class))).thenReturn(Mono.empty());
         when(this.deleteAppTaskDelegate.deleteApp(any(CloudFoundryOperations.class), any(CfProperties.class))).thenReturn(Mono.empty());
         when(this.stopDelegate.stopApp(any(CloudFoundryOperations.class), any(CfProperties.class))).thenReturn(Mono.empty());

--- a/src/test/java/io/pivotal/services/plugin/tasks/helper/CfMapRouteDelegateTest.java
+++ b/src/test/java/io/pivotal/services/plugin/tasks/helper/CfMapRouteDelegateTest.java
@@ -1,0 +1,110 @@
+package io.pivotal.services.plugin.tasks.helper;
+
+import io.pivotal.services.plugin.CfProperties;
+import io.pivotal.services.plugin.ImmutableCfProperties;
+import org.cloudfoundry.operations.CloudFoundryOperations;
+import org.cloudfoundry.operations.domains.Domain;
+import org.cloudfoundry.operations.domains.Domains;
+import org.cloudfoundry.operations.domains.Status;
+import org.cloudfoundry.operations.routes.MapRouteRequest;
+import org.cloudfoundry.operations.routes.Routes;
+import org.junit.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+/**
+ * @author Biju Kunjummen
+ */
+public class CfMapRouteDelegateTest {
+
+
+    @Test
+    public void mapRoutesNoExplicitRoutes() {
+        CfMapRouteDelegate cfMapRouteDelegate = new CfMapRouteDelegate();
+        CloudFoundryOperations cfOperations = mock(CloudFoundryOperations.class);
+        Routes mockRoutes = mock(Routes.class);
+        when(mockRoutes.map(any(MapRouteRequest.class))).thenReturn(Mono.just(123));
+        when(cfOperations.routes()).thenReturn(mockRoutes);
+        CfProperties cfProperties = sampleApp(Collections.emptyList());
+        Flux<Integer> result = cfMapRouteDelegate.mapRoute(cfOperations, cfProperties);
+        StepVerifier.create(result)
+            .expectNext(123)
+            .expectComplete().verify();
+    }
+
+    @Test
+    public void mapRoutesExplicitWithValidDomains() {
+        CfMapRouteDelegate cfMapRouteDelegate = new CfMapRouteDelegate();
+        CloudFoundryOperations cfOperations = mock(CloudFoundryOperations.class);
+        Routes mockRoutes = mock(Routes.class);
+        when(mockRoutes.map(any(MapRouteRequest.class))).thenReturn(Mono.just(123));
+        when(cfOperations.routes()).thenReturn(mockRoutes);
+        Domains mockDomains = mock(Domains.class);
+        when(mockDomains.list())
+            .thenReturn(
+                Flux.just(
+                    Domain.builder().id("id1").name("test1.domain").type("typ").status(Status.SHARED).build(),
+                    Domain.builder().id("id2").name("test2.domain").type("typ").status(Status.SHARED).build()
+                )
+            );
+
+        when(cfOperations.domains()).thenReturn(mockDomains);
+        CfProperties cfProperties = sampleApp(Arrays.asList("app1.test1.domain", "app2.test2.domain"));
+        Flux<Integer> result = cfMapRouteDelegate
+            .mapRoute(cfOperations, cfProperties);
+        StepVerifier.create(result)
+            .expectNext(123)
+            .expectNext(123)
+            .expectComplete()
+            .verify();
+    }
+
+    @Test
+    public void mapRoutesExplicitWithInvalidDomains() {
+        CfMapRouteDelegate cfMapRouteDelegate = new CfMapRouteDelegate();
+        CloudFoundryOperations cfOperations = mock(CloudFoundryOperations.class);
+        Routes mockRoutes = mock(Routes.class);
+        when(mockRoutes.map(any(MapRouteRequest.class))).thenReturn(Mono.just(123));
+        when(cfOperations.routes()).thenReturn(mockRoutes);
+        Domains mockDomains = mock(Domains.class);
+        when(mockDomains.list())
+            .thenReturn(
+                Flux.just(
+                    Domain.builder().id("id1").name("test1.domain").type("typ").status(Status.SHARED).build(),
+                    Domain.builder().id("id2").name("test2.domain").type("typ").status(Status.SHARED).build()
+                )
+            );
+
+        when(cfOperations.domains()).thenReturn(mockDomains);
+        CfProperties cfProperties = sampleApp(Arrays.asList("app1.test1.domain", "app2.invalid.domain"));
+        Flux<Integer> result = cfMapRouteDelegate
+            .mapRoute(cfOperations, cfProperties);
+        StepVerifier.create(result)
+            .expectError(IllegalArgumentException.class)
+            .verify();
+    }
+    
+    private CfProperties sampleApp(List<String> routes) {
+        return ImmutableCfProperties.builder()
+            .ccHost("cchost")
+            .ccUser("ccuser")
+            .ccPassword("ccpassword")
+            .org("org")
+            .space("space")
+            .name("test")
+            .domain("test.domain")
+            .host("test")
+            .routes(routes)
+            .build();
+    }
+}

--- a/src/test/java/io/pivotal/services/plugin/tasks/helper/CfUnmapDelegateTest.java
+++ b/src/test/java/io/pivotal/services/plugin/tasks/helper/CfUnmapDelegateTest.java
@@ -1,0 +1,108 @@
+package io.pivotal.services.plugin.tasks.helper;
+
+import io.pivotal.services.plugin.CfProperties;
+import io.pivotal.services.plugin.ImmutableCfProperties;
+import org.cloudfoundry.operations.CloudFoundryOperations;
+import org.cloudfoundry.operations.domains.Domain;
+import org.cloudfoundry.operations.domains.Domains;
+import org.cloudfoundry.operations.domains.Status;
+import org.cloudfoundry.operations.routes.MapRouteRequest;
+import org.cloudfoundry.operations.routes.Routes;
+import org.cloudfoundry.operations.routes.UnmapRouteRequest;
+import org.junit.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+/**
+ * @author Biju Kunjummen
+ */
+public class CfUnmapDelegateTest {
+
+
+    @Test
+    public void unmapImplicitRoutes() {
+        CfUnMapRouteDelegate cfUnmap = new CfUnMapRouteDelegate();
+        CloudFoundryOperations cfOperations = mock(CloudFoundryOperations.class);
+        Routes mockRoutes = mock(Routes.class);
+        when(mockRoutes.unmap(any(UnmapRouteRequest.class))).thenReturn(Mono.empty());
+        when(cfOperations.routes()).thenReturn(mockRoutes);
+        CfProperties cfProperties = sampleApp(Collections.emptyList());
+        Flux<Void> result = cfUnmap.unmapRoute(cfOperations, cfProperties);
+        StepVerifier.create(result)
+            .expectComplete().verify();
+    }
+
+    @Test
+    public void unmapExplicitRoutes() {
+        CfUnMapRouteDelegate cfUnmap = new CfUnMapRouteDelegate();
+        CloudFoundryOperations cfOperations = mock(CloudFoundryOperations.class);
+        Routes mockRoutes = mock(Routes.class);
+        when(mockRoutes.unmap(any(UnmapRouteRequest.class))).thenReturn(Mono.empty());
+        when(cfOperations.routes()).thenReturn(mockRoutes);
+        Domains mockDomains = mock(Domains.class);
+        when(mockDomains.list())
+            .thenReturn(
+                Flux.just(
+                    Domain.builder().id("id1").name("test1.domain").type("typ").status(Status.SHARED).build(),
+                    Domain.builder().id("id2").name("test2.domain").type("typ").status(Status.SHARED).build()
+                )
+            );
+
+        when(cfOperations.domains()).thenReturn(mockDomains);
+        
+        CfProperties cfProperties = sampleApp(Arrays.asList("app1.test1.domain", "app2.test2.domain"));
+        Flux<Void> result = cfUnmap.unmapRoute(cfOperations, cfProperties);
+        StepVerifier.create(result)
+            .expectComplete()
+            .verify();
+    }
+
+    @Test
+    public void unmapExplicitRoutesInvalidDomain() {
+        CfUnMapRouteDelegate cfUnmap = new CfUnMapRouteDelegate();
+        CloudFoundryOperations cfOperations = mock(CloudFoundryOperations.class);
+        Routes mockRoutes = mock(Routes.class);
+        when(mockRoutes.unmap(any(UnmapRouteRequest.class))).thenReturn(Mono.empty());
+        when(cfOperations.routes()).thenReturn(mockRoutes);
+        Domains mockDomains = mock(Domains.class);
+        when(mockDomains.list())
+            .thenReturn(
+                Flux.just(
+                    Domain.builder().id("id1").name("test1.domain").type("typ").status(Status.SHARED).build(),
+                    Domain.builder().id("id2").name("test2.domain").type("typ").status(Status.SHARED).build()
+                )
+            );
+
+        when(cfOperations.domains()).thenReturn(mockDomains);
+
+        CfProperties cfProperties = sampleApp(Arrays.asList("app1.test1.domain", "app2.invalid.domain"));
+        Flux<Void> result = cfUnmap.unmapRoute(cfOperations, cfProperties);
+        StepVerifier.create(result)
+            .expectError(IllegalArgumentException.class)
+            .verify();
+    }    
+
+    private CfProperties sampleApp(List<String> routes) {
+        return ImmutableCfProperties.builder()
+            .ccHost("cchost")
+            .ccUser("ccuser")
+            .ccPassword("ccpassword")
+            .org("org")
+            .space("space")
+            .name("test")
+            .domain("test.domain")
+            .host("test")
+            .routes(routes)
+            .build();
+    }
+}


### PR DESCRIPTION
* Removes cache for domains.
**Background**:  Prior to this change the domains in a CF environment were being eagerly cached. This was not really for performance reasons but because the call for domains was a blocking call and this blocking call in a reactive flow ended up hanging the cf-java-client(see https://github.com/cloudfoundry/cf-java-client/issues/597 for the description of a similar issue). This commit now makes the call for domains reactive and now with everything reactive, the cache is no longer required.

* Adds additional tests for map and unmap of routes