### PR TITLE
Support green subdomain when not using host in route

### DIFF
--- a/src/main/java/io/pivotal/services/plugin/CfRouteUtil.java
+++ b/src/main/java/io/pivotal/services/plugin/CfRouteUtil.java
@@ -53,7 +53,7 @@ public class CfRouteUtil {
     }
 
     private static Mono<String> getTempRoute(String host, String domain, Integer port, String path, String suffix) {
-        return Mono.just((host != null ? host + suffix + "." : suffix + ".")
+        return Mono.just((host != null ? host + "-" + suffix + "." : suffix + ".")
             + domain
             + (port != null ? ":" + port : "")
             + (path != null ? "/" + path : ""));

--- a/src/main/java/io/pivotal/services/plugin/tasks/helper/CfBlueGreenStage1Delegate.java
+++ b/src/main/java/io/pivotal/services/plugin/tasks/helper/CfBlueGreenStage1Delegate.java
@@ -33,7 +33,7 @@ public class CfBlueGreenStage1Delegate {
                                 CfProperties cfProperties) {
         
         final String greenNameString = cfProperties.name() + "-green";
-        final Mono<String> greenRouteStringMono = CfRouteUtil.getTempRoute(cfOperations, cfProperties, "-green");
+        final Mono<String> greenRouteStringMono = CfRouteUtil.getTempRoute(cfOperations, cfProperties, "green");
 
         Mono<Optional<ApplicationDetail>> appDetailMono = appDetailsDelegate
             .getAppDetails(cfOperations, cfProperties);

--- a/src/main/java/io/pivotal/services/plugin/tasks/helper/CfBlueGreenStage2Delegate.java
+++ b/src/main/java/io/pivotal/services/plugin/tasks/helper/CfBlueGreenStage2Delegate.java
@@ -62,7 +62,7 @@ public class CfBlueGreenStage2Delegate {
                                 CfProperties cfProperties) {
         
         String greenNameString = cfProperties.name() + "-green";
-        Mono<String> greenRouteMono = CfRouteUtil.getTempRoute(cfOperations, cfProperties, "-green");
+        Mono<String> greenRouteMono = CfRouteUtil.getTempRoute(cfOperations, cfProperties, "green");
 
         CfProperties greenName = ImmutableCfProperties.copyOf(cfProperties)
             .withName(greenNameString);


### PR DESCRIPTION
This update is to fix the subdomain on the route when the host parameter is empty. When the host parameter is empty it results in a route with a `-green` subdomain