### PR TITLE
fix the bug of String to Integer for gradle project properties

### DIFF
--- a/src/main/java/io/pivotal/services/plugin/CfPropertiesMapper.java
+++ b/src/main/java/io/pivotal/services/plugin/CfPropertiesMapper.java
@@ -405,7 +405,7 @@ public class CfPropertiesMapper {
      */
     public Optional<Integer> getIntegerPropertyFromProject(String propertyName) {
         if (this.project.hasProperty(propertyName)) {
-            return Optional.of((Integer) this.project.property(propertyName));
+            return Optional.of(Integer.parseInt(this.project.property(propertyName)));
         }
         return Optional.empty();
     }


### PR DESCRIPTION
Description: 
When I use the plugin to deploy cf:
 gradle -Pcf.instances=3 -Pcf.ccUser=**** -Pcf.ccPassword=****  cf-push-autopilot 
FAILURE: Build failed with an exception.
* What went wrong:
Execution failed for task ':cf-push-autopilot'.
> class java.lang.String cannot be cast to class java.lang.Integer (java.lang.String and java.lang.Integer are in module java.base of loader 'bootstrap')

The root cause is  -Pcf.instances=3 string "3" can't be converted to integer 3. So I have to check the source code of the plugin and fixed it.
